### PR TITLE
refreshing 1.5.3 archive

### DIFF
--- a/com.sleepfiles.OSCAR.metainfo.xml
+++ b/com.sleepfiles.OSCAR.metainfo.xml
@@ -29,7 +29,7 @@
 	<update_contact>erico.mendonca@gmail.com</update_contact>
 	<translation type="qt">/usr/share/OSCAR/Translations</translation>
 	<releases>
-		<release date="2024-05-01" version="1.5.3"/>
+		<release date="2024-05-22" version="1.5.3"/>
 		<release date="2024-03-15" version="1.5.2"/>
 		<release date="2023-11-03" version="1.5.1"/>
 		<release date="2023-09-13" version="1.5.0"/>

--- a/com.sleepfiles.OSCAR.yaml
+++ b/com.sleepfiles.OSCAR.yaml
@@ -48,8 +48,8 @@ modules:
       - LIBS+=-L/app/lib
     sources:
       - type: archive
-        url: https://gitlab.com/pholy/OSCAR-code/-/archive/1.5.3/OSCAR-code-v1.5.3.tar.bz2
-        sha256: 643600f5abab3904aab82cadfb767518b966ac7e1783a7a40ca1ed1edbf97962
+        url: https://gitlab.com/pholy/OSCAR-code/-/archive/1.5.3/OSCAR-code-1.5.3.tar.bz2
+        sha256: 76f80321255f7cbba274a963f62ce801fc1a4e2371d20f2950ebbc13ad6d3992
       - type: file
         path: com.sleepfiles.OSCAR.metainfo.xml
     build-commands:


### PR DESCRIPTION
Correcting the URL for version 1.5.3. The upstream changed the way the branches are named (1.5.3 vs v1.5.3 previously), so gitlab was silently failing and delivering the branch for 1.5.2.
