### PR TITLE
Add QT_QPA_PLATFORMTHEME env to guarantee readable text

### DIFF
--- a/com.sleepfiles.OSCAR.yaml
+++ b/com.sleepfiles.OSCAR.yaml
@@ -5,7 +5,7 @@
 
 # Special OBS field because flatpak does not have a version field
 # Default will be '0' if the field is missing.
-#!BuildVersion: 1.6.0
+#!BuildVersion: 1.7.0
 ---
 app-id: com.sleepfiles.OSCAR
 runtime: org.kde.Platform
@@ -21,6 +21,7 @@ finish-args:
   - --filesystem=home
   - --filesystem=/media
   - --filesystem=/run/media
+  - --env=QT_QPA_PLATFORMTHEME=gtk3
   - --device=dri
 build-options:
   env:


### PR DESCRIPTION
* Increment BuildVersion comment to match the actual current source (v1.7.0)
* Fix the text coloring issue for systems running dark themes natively (OSCAR does not support dark themes, and thus text is not readable).


By having this ENV included in the manifest by default, the text is readable regardless of system theme.

Mock data used in profile for demo to show the issue:
BEFORE:
<img width="1018" height="692" alt="image" src="https://github.com/user-attachments/assets/ca5f8e63-9dc2-4fbf-aa39-05945ea0a032" />


AFTER:
<img width="1168" height="757" alt="image" src="https://github.com/user-attachments/assets/1a9cd6ff-edb9-40b9-8762-26fcaaa7ae48" />
