### PR TITLE
Update runtime to from 5.15-24.08 to 6.10 and more

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/com.sleepfiles.OSCAR.metainfo.xml
+++ b/com.sleepfiles.OSCAR.metainfo.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<component type="desktop">
+<component type="desktop-application">
 	<id>com.sleepfiles.OSCAR</id>
 	<metadata_license>CC0-1.0</metadata_license>
 	<project_license>GPL-3.0</project_license>
@@ -9,14 +9,13 @@
 		<p>OSCAR is PC software developed for reviewing and exploring data produced by CPAP and related machines used in the treatment of sleep apnea.</p>
 	</description>
 	<launchable type="desktop-id">com.sleepfiles.OSCAR.desktop</launchable>
-	<url type="homepage">https://sleepfiles.com/OSCAR/</url>
 	<content_rating type="oars-1.1"/>
 	<screenshots>
 		<screenshot>
-			<image>https://github.com/doccaz/com.sleepfiles.OSCAR/raw/refs/heads/master/OSCAR_Welcome_Screen.PNG</image>
+			<image>https://raw.githubusercontent.com/flathub/com.sleepfiles.OSCAR/b7855b9b4b3afa830427d7d2cc037fd5bee020cf/OSCAR_Welcome_Screen.png</image>
 		</screenshot>
 		<screenshot type="default">
-			<image>https://github.com/doccaz/com.sleepfiles.OSCAR/raw/refs/heads/master/OSCAR_daily_screen.png</image>
+			<image>https://raw.githubusercontent.com/flathub/com.sleepfiles.OSCAR/b7855b9b4b3afa830427d7d2cc037fd5bee020cf/OSCAR_daily_screen.png</image>
 		</screenshot>
 	</screenshots>
 	<provides>
@@ -27,30 +26,27 @@
 		<category>MedicalSoftware</category>
 	</categories>
 	<update_contact>erico.mendonca@gmail.com</update_contact>
-	<translation type="qt">/usr/share/OSCAR/Translations</translation>
+	<!--<translation type="qt">/usr/share/OSCAR/Translations</translation> -->
 	<releases>
-		<release date="2025-12-04" version="1.7.0"/>
-		<release date="2025-07-28" version="1.6.1"/>
-		<release date="2024-12-12" version="1.6.0"/>
-		<release date="2024-05-22" version="1.5.3"/>
-		<release date="2024-03-15" version="1.5.2"/>
-		<release date="2023-11-03" version="1.5.1"/>
-		<release date="2023-09-13" version="1.5.0"/>
-		<release date="2022-09-10" version="1.4.0"/>
+		<release version="1.7.1" date="2026-04-28"/>
+		<release version="1.7.0" date="2025-12-04" />
+		<release version="1.6.1" date="2025-07-28" />
+		<release version="1.6.0" date="2024-12-12" />
+		<release version="1.5.3" date="2024-05-22" />
+		<release version="1.5.2" date="2024-03-15" />
+		<release version="1.5.1" date="2023-11-03"/>
+		<release version="1.5.0" date="2023-09-13"/>
+		<release version="1.4.0" date="2022-09-10"/>
 	</releases>
 
-	<!--FIXME: You can use a project or developer name if there's no company-->
-	<developer_name>The OSCAR Team</developer_name>
-
-	<!--FIXME: where to report bugs for the application-->
+	<developer id="com.sleepfiles">
+		<name>The OSCAR Team</name>
+	</developer>
+	<url type="homepage">https://sleepfiles.com/OSCAR</url>
 	<url type="bugtracker">https://gitlab.com/CrimsonNape/OSCAR-code/-/issues</url>
-
-	<!--FIXME: where to donate to the application-->
-	<url type="donation">https://www.sleepfiles.com/OSCAR/</url>
-
-	<!--FIXME: where on the internet users can find help-->
-	<url type="help">http://www.apneaboard.com/wiki/index.php/OSCAR_Help</url>
-
-	<!--FIXME: where to submit translations-->
-	<url type="translate">http://www.apneaboard.com/wiki/index.php/Translators</url>
+	<url type="vcs-browser">https://gitlab.com/CrimsonNape/OSCAR-code</url>
+	<url type="donation">https://www.sleepfiles.com/OSCAR</url>
+	<url type="help">https://www.apneaboard.com/wiki/index.php/OSCAR_Help</url>
+	<url type="translate">https://www.apneaboard.com/wiki/index.php/Translators</url>
+	<url type="contribute">https://gitlab.com/CrimsonNape/OSCAR-code/-/blob/master/CONTRIBUTING.md</url>
 </component>

--- a/com.sleepfiles.OSCAR.yaml
+++ b/com.sleepfiles.OSCAR.yaml
@@ -1,15 +1,6 @@
-######################################################
-# Flatpak manifest for OSCAR
-# Erico Mendonca <erico.mendonca@gmail.com> Jan 2022 
-######################################################
-
-# Special OBS field because flatpak does not have a version field
-# Default will be '0' if the field is missing.
-#!BuildVersion: 1.7.0
----
 app-id: com.sleepfiles.OSCAR
 runtime: org.kde.Platform
-runtime-version: '5.15-24.08'
+runtime-version: '6.10'
 sdk: org.kde.Sdk
 command: OSCAR
 
@@ -27,38 +18,31 @@ build-options:
   env:
     - QMAKE_CXXFLAGS: -L/app/lib
     - QMAKE_LDFLAGS: -L/app/lib
-    
+
 modules:
-  - name: glu
-    config-opts:
-      - --disable-static
-    sources:
-      - type: archive
-        url: https://mesa.freedesktop.org/archive/glu/glu-9.0.2.tar.xz
-        sha256: 6e7280ff585c6a1d9dfcdf2fca489251634b3377bfc33c29e4002466a38d02d4
-    cleanup:
-      - /include
-      - '*.a'
-      - '*.la'
-      - /lib/pkgconfig
-  
+  - shared-modules/glu/glu-9.json
+
   - name: OSCAR
     buildsystem: qmake
     config-opts:
       - OSCAR_QT.pro
       - LIBS+=-L/app/lib
+    build-commands:
+      - install -Dm755 oscar/OSCAR ${FLATPAK_DEST}/bin/OSCAR
+      - install -Dm644 Building/Linux/OSCAR.svg ${FLATPAK_DEST}/share/icons/hicolor/scalable/apps/${FLATPAK_ID}.svg
+      - desktop-file-edit --set-icon=com.sleepfiles.OSCAR Building/Linux/OSCAR.desktop
+      - desktop-file-edit --set-comment='Cross-platform sleep tracking program for CPAP and Oximetry data' Building/Linux/OSCAR.desktop
+      - install -Dm644 Building/Linux/OSCAR.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
+      - install -Dm644 com.sleepfiles.OSCAR.metainfo.xml -t ${FLATPAK_DEST}/share/metainfo/
+      # Copy Translation files
+      - cp -dpr oscar/Translations ${FLATPAK_DEST}/bin
     sources:
-      - type: archive
-        url: https://gitlab.com/CrimsonNape/OSCAR-code/-/archive/v1.7.0/OSCAR-code-v1.7.0.tar.bz2
-        sha256: a2fe3fb1e66d8ace31aa3743d702c095804caf7d7c600c2d07e21f91e94ab600
+      - type: git
+        url: https://gitlab.com/CrimsonNape/OSCAR-code.git
+        tag: v1.7.1
+        commit: 4b92097b0ee0e5b09b8030e083faa60aab76937c
+        x-checker-data:
+          type: git
+          tag-pattern: ^v([\d.]+)$
       - type: file
         path: com.sleepfiles.OSCAR.metainfo.xml
-    build-commands:
-      # the generated makefiles do not support make install(?)
-      - install -D -m 755 oscar/OSCAR $FLATPAK_DEST/bin/OSCAR
-      - install -D -m 644 Building/Linux/OSCAR.svg $FLATPAK_DEST/share/icons/hicolor/scalable/apps/com.sleepfiles.OSCAR.svg
-      - cp -dpR oscar/{Translations,Html} $FLATPAK_DEST/bin/
-      - install -Dm644 Building/Linux/OSCAR.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
-      - desktop-file-edit --set-icon=com.sleepfiles.OSCAR --set-comment='Cross-platform sleep tracking program for CPAP and Oximetry data' ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
-      - install -D -m 644 com.sleepfiles.OSCAR.metainfo.xml $FLATPAK_DEST/share/metainfo/com.sleepfiles.OSCAR.metainfo.xml
-      

--- a/com.sleepfiles.OSCAR.yaml
+++ b/com.sleepfiles.OSCAR.yaml
@@ -34,8 +34,8 @@ modules:
       - desktop-file-edit --set-comment='Cross-platform sleep tracking program for CPAP and Oximetry data' Building/Linux/OSCAR.desktop
       - install -Dm644 Building/Linux/OSCAR.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop
       - install -Dm644 com.sleepfiles.OSCAR.metainfo.xml -t ${FLATPAK_DEST}/share/metainfo/
-      # Copy Translation files
-      - cp -dpr oscar/Translations ${FLATPAK_DEST}/bin
+      # Copy Translation and HTML files
+      - cp -dpR oscar/{Translations,Html} $FLATPAK_DEST/bin/      
     sources:
       - type: git
         url: https://gitlab.com/CrimsonNape/OSCAR-code.git


### PR DESCRIPTION
- Update the runtime version to 6.10
- Update app version to 1.7.1
- Add checker-data for the main module
- Use the glu module from shared-modules
- Fix appdata paper cuts
- Drop redundant HTML files